### PR TITLE
SpotifyWorker Rewrite 

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -4,4 +4,11 @@ class Artist < ApplicationRecord
   has_many :events, through: :event_artists, dependent: :destroy
   has_many :artist_genres, dependent: :destroy
   has_many :genres, through: :artist_genres
+
+  # TODO: use nested attributes
+  def genre_list=(genre_names)
+    genre_names.each do |genre_name|
+      genres.find_or_create_by name: genre_name
+    end
+  end
 end

--- a/app/workers/spotify_worker.rb
+++ b/app/workers/spotify_worker.rb
@@ -1,169 +1,142 @@
+# frozen_string_literal: true
+
 class SpotifyWorker
+  DEFAULT_QUERY_PARAMS ||= { offset: 0, limit: 50 }.freeze
+
   include Sidekiq::Worker
-  include SidekiqStatus::Worker #this is the sidekiq status module
+  include SidekiqStatus::Worker
+
   sidekiq_options retry: false
 
   def perform(current_user_id)
-    @user = User.find(current_user_id)
+    @user = User.find current_user_id
     self.total = 100
-    at 0
-    artists_image_and_genre
+
+    fetch_playlists
+    at 20
+    fetch_tracks
+    at 70
+    find_or_create_artists
+    at 80
+    sync_artists
+    at 90
+    link_artists_to_user
+    at 100
   end
 
   private
 
-  def playlists_ids_parsing(offset)
-    at 5
-    url = "https://api.spotify.com/v1/users/#{@user.spotify_id}/playlists?limit=50&offset=#{offset}"
-    playlists_serialized = RestClient::Resource.new(url, headers: {accept: "application/json", authorization: "Bearer #{@user.auth_token}"})
-    @partial_playlist = JSON.parse(playlists_serialized.get)
+  # specific
+
+  def fetch_playlists
+    log 'fetching playlists'
+    @playlists = fetch_records path: user_playlists_request_path
   end
 
-  def playlists_ids_storing
-    playlists_ids_parsing(0)
-    at 20
-    all_playlists = []
-    @partial_playlist["items"].each do |playlist|
-      all_playlists << playlist
-    end
-
-    if all_playlists.count % 50 != 0
-      all_playlists
-    else
-      i = 50
-      until all_playlists.count % 50 != 0
-        playlists_ids_parsing(i)
-        @partial_playlist["items"].each do |playlist|
-          all_playlists << playlist
-        end
-        i += 50
-      end
-    end
-    unwanted_playlists = all_playlists.map do |playlist|
-      if playlist["owner"]["id"] != @user.spotify_id
-        playlist
-      end
-    end
-    unwanted_playlists.delete(nil)
-    playlists = all_playlists - unwanted_playlists
-    @playlists_ids = playlists.map do |playlist|
-      playlist["id"]
-    end
-    return @playlists_ids
-  end
-
-  def get_tracks_artists
-    tracks = []
-    playlists_ids_storing.each do |playlist_id|
-      url = "https://api.spotify.com/v1/users/#{@user.spotify_id}/playlists/#{playlist_id}/tracks"
-      tracks_serialized = RestClient::Resource.new(url, headers: {accept: "application/json", authorization: "Bearer #{@user.auth_token}"})
-      tracks << JSON.parse(tracks_serialized.get)
-    end
-    at 40
-    @names_and_ids = []
-    @artists_ids = []
-    @artists_names_and_ids = tracks.map do |playlist_tracks|
-      playlist = playlist_tracks["items"]
-      playlist.each do |track|
-        unless track["track"].nil? || track["track"]["artists"][0]["uri"].nil?
-          name_and_id = []
-          track_artist_name = track["track"]["album"]["artists"][0]["name"]
-          track_artist_id = track["track"]["album"]["artists"][0]["id"]
-          name_and_id << track_artist_name
-          name_and_id << track_artist_id
-          @artists_ids << track_artist_id
-          @names_and_ids << name_and_id unless @names_and_ids.include?(name_and_id)
-        end
-      end
-    end
-    @names_and_ids
-  end
-
-  def artists_persistence
-    get_tracks_artists
-    at 60
-    @names_and_ids.each do |artist_array|
-      artist = Artist.where(name: artist_array[0])
-      unless artist.empty?
-        unless @user.artists.include?(artist[0])
-          new_user_artist = UserArtist.new()
-          new_user_artist.artist = artist[0]
-          new_user_artist.user = @user
-          new_user_artist.save
-        end
-      else
-        new_artist = Artist.new(name: artist_array[0], spotify_id: artist_array[1])
-        new_artist.save
-        new_user_artist = UserArtist.new()
-        new_user_artist.artist = new_artist
-        new_user_artist.user = @user
-        new_user_artist.save
-      end
-    end
-    @user.artists.each do |artist|
-      unless @artists_ids.include?(artist.spotify_id)
-        user_artist_to_destroy = UserArtist.find_by(artist_id: artist.id, user_id: @user.id)
-        user_artist_to_destroy.delete
-      end
+  def fetch_tracks
+    log 'fetching tracks'
+    @tracks = owned_playlists.flat_map do |playlist|
+      uri = with_query_params playlist.dig :tracks, :href
+      fetch_records uri: uri
     end
   end
 
-  def artists_image_and_genre
-    artists_persistence
-    # get_tracks_artists
-    at 70
-    url = "https://api.spotify.com/v1/artists?ids="
-    url_start_split = url.split("")
-    i = 0
-    j = 49
-    @artists_images_genre = []
-    while j < @names_and_ids.count + 50
-      url_ids = []
-      @names_and_ids[i..j].each do |artist|
-        url_ids << artist[1]
-        url_ids << ","
-      end
-      url = url_start_split + url_ids
-      url.pop
-      url = url.join("")
-      artists_serialized = RestClient::Resource.new(url, headers: {accept: "application/json", authorization: "Bearer #{@user.auth_token}"})
-      artists_parsed = JSON.parse(artists_serialized.get)
-      artists_parsed["artists"].each { |artist| @artists_images_genre << artist }
-      i += 50
-      j += 50
+  # TODO: eager-load existing artists
+  def find_or_create_artists
+    log 'creating artist records'
+    @artist_by_spotify_id = @tracks.each_with_object({}) do |track, memo|
+      artist_spotify_id = track.dig :track, :album, :artists, 0, :id
+      memo[artist_spotify_id] ||= Artist.find_or_create_by spotify_id: artist_spotify_id
     end
-    # @artists_images_genre = @names_and_ids.map do |artist|
-    #   url = "https://api.spotify.com/v1/artists/#{artist[1]}"
-    #   artists_serialized = RestClient::Resource.new(url, headers: {accept: "application/json", authorization: "Bearer #{@user.auth_token}"})
-    #   @artist = JSON.parse(artists_serialized.get)
-    # end
-    at 80
-    @artists_images_genre.each do |a|
-      artist_to_update = Artist.where(name: a["name"])[0]
-      artist_to_update.update(images: a["images"][0]["url"]) unless a["images"].empty? || Artist.where(name: a["name"])[0].nil? #Needs to be fixed, second condition shouldn't have to exist to prevent 'undefined method `genres'' error
-        new_artist_genre = ArtistGenre.new()
-      artist_genres = a["genres"]
-      unless a["genres"].empty?
-        artist_genres.each do |genre_name|
-          genre = Genre.where(name: genre_name)
-          if genre.exists?
-            unless artist_to_update.nil? || artist_to_update.genres.include?(genre[0]) #Needs to be fixed, second condition shouldn't have to exist to prevent 'undefined method `genres'' error
-              new_artist_genre = ArtistGenre.new()
-              new_artist_genre.genre = genre[0]
-              new_artist_genre.artist = artist_to_update
-              new_artist_genre.save
-            end
-          else
-            new_genre = Genre.new(name: genre_name)
-            new_genre.save
-            new_artist_genre = ArtistGenre.new()
-            new_artist_genre.genre = new_genre
-            new_artist_genre.artist = artist_to_update
-            new_artist_genre.save
-          end
-        end
+  end
+
+  # TODO: skip artists which have been updated recently
+  def sync_artists
+    log 'syncing artist records'
+    @artist_by_spotify_id.keys.each_slice(50) do |ids|
+      uri = request_uri path: 'v1/artists', query: 'ids=' + ids.join(',')
+      data = fetch(uri)[:artists] || []
+      data.each { |record| update_artist record }
+    end
+  end
+
+  def link_artists_to_user
+    log 'linking artists to user'
+    @user.artists += @artist_by_spotify_id.values
+  end
+
+  def update_artist(data)
+    id, name, genres, images = data.values_at :id, :name, :genres, :images
+
+    @artist_by_spotify_id[id]
+      .update name: name,
+              genre_list: genres,
+              images: images.dig(0, :url)
+  end
+
+  def user_playlists_request_path
+    [ 'v1',
+      'users',
+      @user.spotify_id,
+      'playlists'
+    ].join('/')
+  end
+
+  def owned_playlists
+    @playlists.select do |playlist|
+      playlist.dig(:owner, :id) == @user.spotify_id
+    end
+  end
+
+  # generic
+
+  def request_uri(path:, query: DEFAULT_QUERY_PARAMS)
+    query_string = query.is_a?(String) ? query : query.to_query
+    URI::HTTPS
+      .build host: 'api.spotify.com',
+             path: '/' + path,
+             query: query_string
+  end
+
+  def with_query_params(uri_string, params = {})
+    URI.parse(uri_string).tap do |uri|
+      uri.query =
+        URI
+          .decode_www_form(uri.query.to_s)
+          .to_h
+          .reverse_merge(DEFAULT_QUERY_PARAMS)
+          .merge(params)
+          .to_query
+    end
+  end
+
+  def fetch_records(uri: nil, path: nil)
+    uri ||= request_uri path: path
+
+    [].tap do |results|
+      loop do
+        data = fetch uri
+        results.concat data[:items] || []
+        break unless uri = data[:next]
       end
     end
-    at 100
+  end
+
+  def fetch(uri)
+    log "Sending request at #{uri}"
+    response = RestClient::Resource
+                 .new(uri.to_s,
+                      headers: { accept: 'application/json',
+                                 authorization: "Bearer #{@user.auth_token}"
+                               })
+                 .get
+
+    JSON
+      .parse(response)
+      .with_indifferent_access
+  end
+
+  def log(message)
+    Rails.logger.info "SpotifyWorker: #{message}"
   end
 end


### PR DESCRIPTION
This rewrite try to replicate the original code behavior with the following exceptions:
* it fixes the infinite loop bug;
* it doesn't try to remove artist associations from user;
* it uses slightly different values for SidekiqStatus;
* it adds some logging.

It is using only pure Ruby code (with ActiveSupport) and keep all code (apart from the `genre_list` setter method) in the worker. We could extract the specific part of the code to a service object and the generic code in a concern for example.